### PR TITLE
Update scoped_caller.h

### DIFF
--- a/scoped_caller.h
+++ b/scoped_caller.h
@@ -16,11 +16,14 @@ public:
 	ScopedCaller(F&& i_f, Args&&... i_args)
 		: m_uncaught_exceptions{ std::uncaught_exceptions() }
 	{
-		auto callback = std::make_shared < std::function<std::result_of<F(Args...)>::type()> >(
-			std::bind(std::forward<F>(i_f), std::forward<Args>(i_args)...)
-			);
+		auto callback = 
+			std::bind(std::forward<F>(i_f), std::forward<Args>(i_args)...);
 
-		m_callback = [callback] { (*callback)(); };
+		m_callback = std::function<void()> {
+			// move callback to the lambda capture,
+			// since we don't need it in this scope anymore
+			[callback = std::move(callback)] { callback(); }
+		};
 	}
 
 	~ScopedCaller()


### PR DESCRIPTION
1. Eliminated the need of extra `std::function` construction.
2. And the need of heap allocation in `std::shared_ptr`
Now lambda owns callback directly.

P. S. Unless previous design was made to support threading, this version, to my mind is simpler. 
Saying this because i am a total newbie in threading.